### PR TITLE
Accelerate mz3 for Matlab

### DIFF
--- a/matlab/private/readMz3.m
+++ b/matlab/private/readMz3.m
@@ -1,5 +1,5 @@
-function [faces, vertices, vertexColors, data] = readMz3(filename)
-%function [faces, vertices, vertexColors, data] = readMz3(fileName)
+function [faces, vertices, vertexColors] = readMz3(filename)
+%function [faces, vertices, vertexColors] = readMz3(fileName)
 %inputs:
 %	filename: the nv file to open
 %outputs:
@@ -12,13 +12,12 @@ function [faces, vertices, vertexColors, data] = readMz3(filename)
 faces = [];
 vertices = [];
 vertexColors = [];
-data = [];
 if ~exist(filename,'file'), error('Unable to find MZ3 file named "%s"', filename); return; end;
 fid = fopen(filename,'r','ieee-le');
 magic = fread(fid, 1, 'uint16');
 if (magic ~= 23117) 
     fclose(fid);
-    [faces, vertices, vertexColors, data] = readMz3Gz(filename);
+    [faces, vertices, vertexColors] = readMz3Gz(filename);
     return;
 end
 attr = fread(fid, 1, 'uint16');
@@ -61,8 +60,8 @@ fclose(fid);
 %end readMz3()
 
 
-function [faces, vertices, vertexColors, data] = readMz3Gz(filename)
-%function [faces, vertices, vertexColors, data] = readMz3(fileName)
+function [faces, vertices, vertexColors] = readMz3Gz(filename)
+%function [faces, vertices, vertexColors] = readMz3(fileName)
 %inputs:
 %	filename: the nv file to open
 %outputs:


### PR DESCRIPTION
Block reading added to Matlab mz3 reader which will accelerate [MRIcroS](https://github.com/bonilhamusclab/MRIcroS)


before:
```
    {'raw.mz3'     }    5.8983e+06      206.03   
  
```
after:
```
    {'raw.mz3'     }    5.8983e+06      74.375   
```